### PR TITLE
Change string interpolation implementation

### DIFF
--- a/src/TestsFormRequests.php
+++ b/src/TestsFormRequests.php
@@ -218,7 +218,7 @@ trait TestsFormRequests
             $this->assertContains(
                 $message,
                 $errors,
-                "Failed to find the validation message '${message}' in the validation messages"
+                "Failed to find the validation message '{$message}' in the validation messages"
             );
         }
 


### PR DESCRIPTION
String interpolation with the dollar sign outside the brackets is deprecated in php 8.2, hence the need for this change.